### PR TITLE
Fixed compile errors in combobox and entrycompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ A tutorial to further explain the use of each widget may be written in the futur
 
 [Geronimo Bareiro](https://github.com/gerito1)
 
+[Douglas Chidester](https://github.com/objectDisorientedProgrammer)
+
 ## To contribute
 
 Just submit a pull request, or open an issue.

--- a/combobox.vala
+++ b/combobox.vala
@@ -8,7 +8,7 @@ using Gtk;
 
 public class Example : Window
 {
-    private ListStore liststore;
+    private Gtk.ListStore liststore;
     private ComboBox combobox;
     private CellRendererText cellrenderertext;
 
@@ -17,7 +17,7 @@ public class Example : Window
         this.title = "ComboBox";
         this.destroy.connect(Gtk.main_quit);
 
-        liststore = new ListStore(1, typeof (string));
+        liststore = new Gtk.ListStore(1, typeof (string));
         Gtk.TreeIter iter;
 
         liststore.append(out iter);

--- a/entrycompletion.vala
+++ b/entrycompletion.vala
@@ -7,7 +7,7 @@ using Gtk;
 
 public class EntryExample : Window
 {
-    private ListStore liststore;
+    private Gtk.ListStore liststore;
     private Entry entry;
     private EntryCompletion entrycompletion;
 
@@ -19,7 +19,7 @@ public class EntryExample : Window
         entry = new Entry();
         this.add(entry);
 
-        liststore = new ListStore(1, typeof(string));
+        liststore = new Gtk.ListStore(1, typeof(string));
 
         Gtk.TreeIter iter;
         liststore.append(out iter);


### PR DESCRIPTION
Trying to build returned this error:
```
entrycompletion.vala:10.13-10.21: error: `ListStore' is an ambiguous reference between `GLib.ListStore' and `Gtk.ListStore'
    private ListStore liststore;
            ^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
```
Fixed by adding `Gtk.` to the `ListStore` variable.